### PR TITLE
only set VIRTUAL_TERINAL_INPUT as console mode upon init

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl Getch {
         unsafe {
             let input_handle = GetStdHandle(STD_INPUT_HANDLE);
             if GetConsoleMode(input_handle, &mut console_mode) != 0 {
-                SetConsoleMode(input_handle, (console_mode | ENABLE_VIRTUAL_TERMINAL_INPUT) & !ENABLE_LINE_INPUT);
+                SetConsoleMode(input_handle, ENABLE_VIRTUAL_TERMINAL_INPUT);
             }
         }
 


### PR DESCRIPTION
If for example mouse input was enabled before sisterm runs, all mouse input will be redirected to the terminal, which is not wanted (in most cases).
Therefore we just overwrite the previous mode and restore it on drop (already implemented)

closes #6